### PR TITLE
Bug Fix and "Only private" feature

### DIFF
--- a/include/classes/parser_extensions/my_node_visitor.php
+++ b/include/classes/parser_extensions/my_node_visitor.php
@@ -544,6 +544,22 @@ class MyNodeVisitor extends PhpParser\NodeVisitorAbstract       // all parsing a
                             throw new Exception("Error: your use of define() function is not compatible with yakpro-po!".PHP_EOL."\tOnly 2 parameters, when first is a literal string is allowed...");
                         }
                     }
+                    else if ($name === 'defined')
+                    {
+                        if (!isset($node->args[0]->value) || !($node->args[0]->value instanceof PhpParser\Node\Scalar\String_))
+                        {
+                            fprintf(STDERR, "Warning: your use of defined() function is not compatible with yakpro-po!".PHP_EOL."\tOnly a literal string is allowed...");   
+                        }
+                        $arg = $node->args[0]->value;
+                        $name = $arg->value;
+
+                        $r = $scrambler->scramble($name);
+                        if ($r !== $name)
+                        {
+                            $arg->value = $r;
+                            $node_modified = true;
+                        }
+                    }
                 }
             }
             if ($node instanceof PhpParser\Node\Expr\ConstFetch)

--- a/include/classes/parser_extensions/my_node_visitor.php
+++ b/include/classes/parser_extensions/my_node_visitor.php
@@ -99,13 +99,8 @@ class MyNodeVisitor extends PhpParser\NodeVisitorAbstract       // all parsing a
         if (!empty($node->class->parts))
         {
             $class = strtolower(implode('\\', $node->class->parts));
-            if ($class === 'static')
-            {
-                $private = !empty($nodes[$this->get_identifier_name($node->name)]);
-                if ($private) fprintf(STDERR, "Warning: your use of static:: can result in shadowing...".PHP_EOL);
-                return $private;
-            }
-            if ($class === 'self' || (!$node->class->isFullyQualified() && $class === $this->current_class_name_obfuscated) ||
+            if ($class === 'self' || $class === 'static' ||
+               (!$node->class->isFullyQualified() && $class === $this->current_class_name_obfuscated) ||
                ($node->class->isFullyQualified() && $class === $this->current_namespace_name . '\\' . $this->current_class_name_obfuscated))
             {
                 return !empty($nodes[$this->get_identifier_name($node->name)]);

--- a/yakpro-po.cnf
+++ b/yakpro-po.cnf
@@ -56,43 +56,43 @@ $conf->scramble_length                  = 5;            // min length of scrambl
 
 $conf->t_obfuscate_php_extension        = array('php'); // array where values are extensions of php files to be obfuscated.
 
-$conf->obfuscate_constant_name          = true;         // self explanatory
-$conf->obfuscate_variable_name          = true;         // self explanatory
-$conf->obfuscate_function_name          = true;         // self explanatory
-$conf->obfuscate_class_name             = true;         // self explanatory
-$conf->obfuscate_interface_name         = true;         // self explanatory
-$conf->obfuscate_trait_name             = true;         // self explanatory
-$conf->obfuscate_class_constant_name    = true;         // self explanatory
-$conf->obfuscate_property_name          = true;         // self explanatory
-$conf->obfuscate_method_name            = true;         // self explanatory
-$conf->obfuscate_namespace_name         = true;         // self explanatory
-$conf->obfuscate_label_name             = true;         // label: , goto label;  obfuscation
-$conf->obfuscate_if_statement           = true;         // obfuscation of  if else elseif statements
-$conf->obfuscate_loop_statement         = true;         // obfuscation of  for while do while statements
-$conf->obfuscate_string_literal         = true;         // pseudo-obfuscation of  string literals
+$conf->obfuscate_constant_name          = true;           // self explanatory
+$conf->obfuscate_variable_name          = true;           // self explanatory
+$conf->obfuscate_function_name          = true;           // self explanatory
+$conf->obfuscate_class_name             = true;           // self explanatory
+$conf->obfuscate_interface_name         = true;           // self explanatory
+$conf->obfuscate_trait_name             = true;           // self explanatory
+$conf->obfuscate_class_constant_name    = true;           // self explanatory
+$conf->obfuscate_property_name          = 'only_private'; // The value can be: false, true or 'only_private'
+$conf->obfuscate_method_name            = true;           // The value can be: false, true or 'only_private'
+$conf->obfuscate_namespace_name         = true;           // self explanatory
+$conf->obfuscate_label_name             = true;           // label: , goto label;  obfuscation
+$conf->obfuscate_if_statement           = true;           // obfuscation of  if else elseif statements
+$conf->obfuscate_loop_statement         = true;           // obfuscation of  for while do while statements
+$conf->obfuscate_string_literal         = true;           // pseudo-obfuscation of  string literals
 
-$conf->shuffle_stmts                    = true;         // shuffle chunks of statements!  disable this obfuscation (or minimize the number of chunks) if performance is important for you!
-$conf->shuffle_stmts_min_chunk_size     =    1;         // minimum number of statements in a chunk! the min value is 1, that gives you the maximum of obfuscation ... and the minimum of performance...
-$conf->shuffle_stmts_chunk_mode         = 'fixed';      // 'fixed' or 'ratio' in fixed mode, the chunk_size is always equal to the min chunk size!
-$conf->shuffle_stmts_chunk_ratio        =   20;         // ratio > 1  100/ratio is the percentage of chunks in a statements sequence  ratio = 2 means 50%  ratio = 100 mins 1% ...
-                                                        // if you increase the number of chunks, you increase also the obfuscation level ... and you increase also the performance overhead!
+$conf->shuffle_stmts                    = true;           // shuffle chunks of statements!  disable this obfuscation (or minimize the number of chunks) if performance is important for you!
+$conf->shuffle_stmts_min_chunk_size     =    1;           // minimum number of statements in a chunk! the min value is 1, that gives you the maximum of obfuscation ... and the minimum of performance...
+$conf->shuffle_stmts_chunk_mode         = 'fixed';        // 'fixed' or 'ratio' in fixed mode, the chunk_size is always equal to the min chunk size!
+$conf->shuffle_stmts_chunk_ratio        =   20;           // ratio > 1  100/ratio is the percentage of chunks in a statements sequence  ratio = 2 means 50%  ratio = 100 mins 1% ...
+                                                          // if you increase the number of chunks, you increase also the obfuscation level ... and you increase also the performance overhead!
 
-$conf->strip_indentation                = true;         // all your obfuscated code will be generated on a single line
-$conf->abort_on_error                   = true;         // self explanatory
-$conf->confirm                          = true;         // rfu : will answer Y on confirmation request (reserved for future use ... or not...)
-$conf->silent                           = false;        // display or not Information level messages.
+$conf->strip_indentation                = true;           // all your obfuscated code will be generated on a single line
+$conf->abort_on_error                   = true;           // self explanatory
+$conf->confirm                          = true;           // rfu : will answer Y on confirmation request (reserved for future use ... or not...)
+$conf->silent                           = false;          // display or not Information level messages.
 
 
-$conf->source_directory                 = null;         // self explanatory
-$conf->target_directory                 = null;         // self explanatory
+$conf->source_directory                 = null;           // self explanatory
+$conf->target_directory                 = null;           // self explanatory
 
-$conf->t_keep                           = null;         // array of directory or file pathnames, to keep 'as is' (i.e. not obfuscate.)
-$conf->t_skip                           = null;         // array of directory or file pathnames, to skip when exploring source tree structure ... they will not be on target!
-$conf->allow_and_overwrite_empty_files  = true;         // allow empty files to be kept as is
+$conf->t_keep                           = null;           // array of directory or file pathnames, to keep 'as is' (i.e. not obfuscate.)
+$conf->t_skip                           = null;           // array of directory or file pathnames, to skip when exploring source tree structure ... they will not be on target!
+$conf->allow_and_overwrite_empty_files  = true;           // allow empty files to be kept as is
 
-$conf->user_comment                     = null;         // user comment to insert inside each obfuscated file
+$conf->user_comment                     = null;           // user comment to insert inside each obfuscated file
 
-$conf->extract_comment_from_line        = null;         // when both 2 are set, each obfuscated file will contain an extract of the corresponding source file,
-$conf->extract_comment_to_line          = null;         // starting from extract_comment_from_line number, and ending at extract_comment_to_line line number.
+$conf->extract_comment_from_line        = null;           // when both 2 are set, each obfuscated file will contain an extract of the corresponding source file,
+$conf->extract_comment_to_line          = null;           // starting from extract_comment_from_line number, and ending at extract_comment_to_line line number.
 
 ?>


### PR DESCRIPTION
Bug found: "Namespace scramble" wasn't covering all cases:
Example:
```php
try {
} catch (MyApp\Logs\Exception $e) {
}
```
In the code above, 'MyApp' and 'Logs' weren't being scrambled.

Another situation when the result code was ill-formed:

```php
\MyApp\Logs\MyClass::doSomething();
```

Besides the bug fix, I also have added a new feature to obfuscate only private properties/methods inside a class. This is an intermediate alternative when we can't obfuscate all methods/properties.

I've used the code below to validate my implementation:

```php
<?php
namespace Tester\Lucas\Obs;

class Test {
    private static $var = 0;
    private static $var2 = 1;
    protected static $var3 = 2;

    public function __construct(){
    }

    public function test($a, $b) {
        return \Tester\Lucas\Obs\Test::compute($a, $b) + self::$var + $this->var3;
    }

    private static function compute($a, $b = 5) {
        if ($b < $a) return self::compute($b, $a);
        $y = $a * $b + Test::$var;
        try {
            $t = $a + $b + \Tester\Lucas\Obs\Test::$var2;
        } catch(\Tester\Rangel\Obs $a) {
        }
        return $y - $t;
    }
}

echo (new Test())->test(1, 2, 3);
```
The result:

```php
namespace vEvel\fTaPJ\ix2Bo;
class z429y {
    private static $QDgoR = 0;
    private static $ArYnb = 1;
    protected static $var3 = 2;
    public function __construct() { }
    public function r9arP($YLAuT, $UwsS1) {
        return \vevEl\ftApJ\ix2bO\z429Y::OEzRa($YLAuT, $UwsS1) + self::$QDgoR + $this->var3;
    }
    private static function OEzrA($YLAuT, $UwsS1 = 5) {
        goto rDTTn;
        FfJ6p:
        return self::oezRa($UwsS1, $YLAuT);
        goto dZ6Xv;
        ZEegy:
        return $Iw_vn - $jENna;
        goto r_BTA;
        iwYTD:
        try {
            $jENna = $YLAuT + $UwsS1 + \veVEl\ftapJ\ix2BO\z429Y::$ArYnb;
        } catch (\vevel\nN3yx\ix2Bo $YLAuT) { }
        goto ZEegy;
        rDTTn:
        if (!($UwsS1 < $YLAuT)) {
            goto WQfMd;
        }
        goto FfJ6p;
        dZ6Xv:
        WQfMd:
        goto b7RtX;
        b7RtX:
        $Iw_vn = $YLAuT * $UwsS1 + z429Y::$QDgoR;
        goto iwYTD;
        r_BTA:
    }
}
echo (new Z429y())->r9aRp(1, 2, 3);
```