### PR TITLE
Allow obfuscation to be only applied on private classmembers

### DIFF
--- a/yakpro-po.cnf
+++ b/yakpro-po.cnf
@@ -64,6 +64,7 @@ $conf->obfuscate_interface_name         = true;         // self explanatory
 $conf->obfuscate_trait_name             = true;         // self explanatory
 $conf->obfuscate_class_constant_name    = true;         // self explanatory
 $conf->obfuscate_property_name          = true;         // self explanatory
+$conf->obfuscate_property_name_private_only = false;    // Only obfuscate private Classmembers or compatibility reasons
 $conf->obfuscate_method_name            = true;         // self explanatory
 $conf->obfuscate_namespace_name         = true;         // self explanatory
 $conf->obfuscate_label_name             = true;         // label: , goto label;  obfuscation


### PR DESCRIPTION
Many libs and other dependencies do not always use getter/setter correctly.
Therefore it might be interesting to only obfuscate private classmembers in order to avoid broken classmember access.

The new option provides this.