### PR TITLE
Adding PHP-Parser as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "PHP-Parser"]
+	path = PHP-Parser
+	url = https://github.com/nikic/PHP-Parser.git

--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ Version 1.0 has been written within a few days...
        # git clone https://github.com/pk-fr/yakpro-po.git 
     4. Go to the yakpro-po directory: 
        # cd yakpro-po 
-    5. Then retrieve from GitHub: 
-       # git clone https://github.com/nikic/PHP-Parser.git 
+    5. Then retrieve submodules from GitHub (PHP-Parser):
+       # git submodule init
+       # git submodule update
     6. Check that yakpro-po.php has execute rights, otherwise:
                                             # chmod a+x yakpro-po.php 
     7. Create a symbolic link in the /usr/local/bin directory


### PR DESCRIPTION
In order to simplify dependencies, this pull request propose to set PHP-Parser as a submodule on the right version directly (last commit at this time of 4.x branch).