### PR TITLE
Strict_types declaration must be the very first statement

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -61,7 +61,7 @@ function obfuscate($filename)                   // takes a file_path as input, r
             $last_use_stmt_pos = -1;
             foreach($stmts as $i => $stmt)                      // if a use statement exists, do not shuffle before the last use statement
             {                                                   //TODO: enhancement: keep all use statements at their position, and shuffle all sub-parts
-                if ( $stmt instanceof PhpParser\Node\Stmt\Use_ || $stmt instanceof PhpParser\Node\Stmt\GroupUse ) $last_use_stmt_pos = $i;
+                if ( $stmt instanceof PhpParser\Node\Stmt\Use_ || $stmt instanceof PhpParser\Node\Stmt\GroupUse || $stmt instanceof PhpParser\Node\Stmt\Declare_ ) $last_use_stmt_pos = $i;
             }
 
             if ($last_use_stmt_pos<0)   { $stmts_to_shuffle = $stmts;                                   $stmts = array();                                       }


### PR DESCRIPTION
Fatal error: strict_types declaration must be the very first statement in the script in declare1.php on line 19

**after obfuscate**
```php
<?php
/*   __________________________________________________
    |  Obfuscated by YAK Pro - Php Obfuscator  2.0.15  |
    |              on 2025-03-07 06:22:17              |
    |    GitHub: https://github.com/pk-fr/yakpro-po    |
    |__________________________________________________|
*/
goto PLe8E;
kGTJ8:
function EJ6QM(int $na5Em, int $jV_J5)
{
    return $na5Em + $jV_J5;
}
goto dqCLi;
dqCLi:
var_dump(eJ6QM(1, 2));
goto h3CwQ;
PLe8E:
declare (strict_types=1);
goto kGTJ8;
h3CwQ:
var_dump(Ej6qm(1.5, 2.5));
```

PHP [declare](https://www.php.net/manual/en/language.types.declarations.php)

```php
<?php
declare(strict_types=1);

function sum(int $a, int $b) {
    return $a + $b;
}

var_dump(sum(1, 2));
var_dump(sum(1.5, 2.5));
?>
```