### PR TITLE
Fix: `NullableType` nodes cause `Undefined property` warning in `scramble_name` / `scramble_names`

### DIFF
--- a/include/classes/parser_extensions/my_node_visitor.php
+++ b/include/classes/parser_extensions/my_node_visitor.php
@@ -69,6 +69,10 @@ class MyNodeVisitor extends PhpParser\NodeVisitorAbstract       // all parsing a
 
     private function scramble_name(&$scrambler, &$node)         // only last part
     {
+        if ($node instanceof PhpParser\Node\NullableType && isset($node->type))
+        {
+            return $this->scramble_name($scrambler, $node->type);
+        }
         if ($node instanceof PhpParser\Node\Name || $node->name instanceof PhpParser\Node\Name)
         {
             if ($node       instanceof PhpParser\Node\Name) $tmp_node = $node;
@@ -91,6 +95,10 @@ class MyNodeVisitor extends PhpParser\NodeVisitorAbstract       // all parsing a
     }
     private function scramble_names(&$scrambler, &$node)        // all except last part
     {
+        if ($node instanceof PhpParser\Node\NullableType && isset($node->type))
+        {
+            return $this->scramble_names($scrambler, $node->type);
+        }
         if ($node instanceof PhpParser\Node\Name || $node->name instanceof PhpParser\Node\Name)
         {
             if ($node       instanceof PhpParser\Node\Name) $tmp_node = $node;
@@ -121,6 +129,10 @@ class MyNodeVisitor extends PhpParser\NodeVisitorAbstract       // all parsing a
     }
     private function scramble_all_names(&$scrambler, &$node)    // all pparts
     {
+        if ($node instanceof PhpParser\Node\NullableType && isset($node->type))
+        {
+            return $this->scramble_all_names($scrambler, $node->type);
+        }
         if ($node instanceof PhpParser\Node\Name || $node->name instanceof PhpParser\Node\Name)
         {
             if ($node       instanceof PhpParser\Node\Name) $tmp_node = $node;


### PR DESCRIPTION
In the file "my_node_visitor.php" the when obfuscating PHP code that uses nullable type hints (`?int`, `?ClassName`, etc.), `scramble_name()` and `scramble_names()` receive a `PhpParser\Node\NullableType` node. These functions check `$node->name instanceof PhpParser\Node\Name` without first checking if `$node` is a `NullableType`, which has `->type` instead of `->name`, producing:
```
Warning: Undefined property: PhpParser\Node\NullableType::$name
```
The `returnType` handling in `leaveNode()` already correctly unwraps `NullableType` before proceeding. This PR applies the same pattern as a guard at the top of the three helper functions, so all callers benefit without needing changes.

Tested with PHP 8.2 + PHP-Parser 5.x (yakpro-po 3.x)